### PR TITLE
fix for issue 38 - ndarraying a range object

### DIFF
--- a/tigramite/independence_tests.py
+++ b/tigramite/independence_tests.py
@@ -751,7 +751,11 @@ class CondIndTest():
             hilbert = np.abs(signal.hilbert(autocov))
             # Try to fit the curve
             try:
-                popt, _ = optimize.curve_fit(func, range(0, max_lag+1), hilbert)
+                popt, _ = optimize.curve_fit(
+                    f=func,
+                    xdata=np.array(range(0, max_lag+1)),
+                    ydata=hilbert,
+                )
                 phi = popt[1]
                 # Formula of Pfeifer (2005) assuming non-overlapping blocks
                 l_opt = (4. * T * (phi / (1. - phi) + phi**2 / (1. - phi)**2)**2
@@ -1922,9 +1926,9 @@ class CMIknn(CondIndTest):
 
     References
     ----------
-    .. [3] J. Runge (2018): Conditional Independence Testing Based on a 
+    .. [3] J. Runge (2018): Conditional Independence Testing Based on a
            Nearest-Neighbor Estimator of Conditional Mutual Information.
-           In Proceedings of the 21st International Conference on Artificial 
+           In Proceedings of the 21st International Conference on Artificial
            Intelligence and Statistics.
            http://proceedings.mlr.press/v84/runge18a.html
 


### PR DESCRIPTION
Line 754 of `independence_tests.py`, which is the line in `_get_block_length()` that calls `scipy`'s `optimize.curve_fit` method, had a bug:

The old line was: 
```python
popt, _ = optimize.curve_fit(func, range(0, max_lag+1), hilbert)
```
Which provides the `xdata` parameter (the second parameter) of `curve_fit` with a `range` object. However, [per the documentation of the method](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.curve_fit.html) the `xadata` parameter _"must be an M-length sequence or an (k,M)-shaped array for functions with k predictors"_, and indeed the method expects the provided object to have the `size` property (which is why this line throws an error, as exemplified in issue #38).

A simple solution, of course, is to explicitly convert the range object to a `numpy.ndarray` object before calling the function, thus eliminating the bug. This PR does just that (and only that). The new code looks like this:

```python
popt, _ = optimize.curve_fit(
    f=func,
    xdata=np.array(range(0, max_lag+1)),
    ydata=hilbert,
)
```

This can be validated to prevent the error thrown by the example code provided by me in issue #38.

I would love to see this merged. :)

Cheers,
Shay