### PR TITLE
Fix broken exception raising (typo)

### DIFF
--- a/tigramite/data_processing.py
+++ b/tigramite/data_processing.py
@@ -103,9 +103,8 @@ class DataFrame():
             if self.values.shape != _use_mask.shape:
                 raise ValueError("shape mismatch: dataframe.values.shape = %s"
                                  % str(self.values.shape) + \
-                                 " but mask.shape = %s,"
-                                 % str(_use_mask.shape)) + \
-                                 "must identical"
+                                 " but mask.shape = %s"
+                                 % str(_use_mask.shape))
 
     def construct_array(self, X, Y, Z, tau_max,
                         mask=None,


### PR DESCRIPTION
My input triggered this exception, but I did not see the useful error message about mismatching shapes. Since the parentheses are wrongly set, the user only sees the interpreter complaining that it cannot add type string to type ValueError.

This pull request suggests a quick fix.