### PR TITLE
Update pcmci.py

### DIFF
--- a/tigramite/pcmci.py
+++ b/tigramite/pcmci.py
@@ -142,6 +142,11 @@ class PCMCI():
         self.dataframe = dataframe
         # Set the conditional independence test to be used
         self.cond_ind_test = cond_ind_test
+        if isinstance(self.cond_ind_test, type):
+            raise ValueError("PCMCI requires that the independence "
+                             "test is instantiated. "
+                             "Please run `cond_ind_test()` before passing "
+                             "the independence test."
         self.cond_ind_test.set_dataframe(self.dataframe)
         # Set the verbosity for debugging/logging messages
         self.verbosity = verbosity


### PR DESCRIPTION
The use of the cond'_int_test input without instantiating produces a confusing error: 

`TypeError: set_dataframe() missing 1 required positional argument: 'dataframe'.` And it refers to line 145 of the pcmci.py file. 
 
Adding this warning allows the user to better understand what exactly is going on and what to do to solve it.