### PR TITLE
Update models.py

### DIFF
--- a/tigramite/models.py
+++ b/tigramite/models.py
@@ -647,7 +647,11 @@ class LinearMediation(Models):
             excluded.
         """
 
-        all_psi_k = np.zeros((self.N, self.tau_max + 1, self.N, self.N))
+        try:
+            all_psi_k = np.zeros((self.N, self.tau_max + 1, self.N, self.N))
+        except np.core._exceptions._ArrayMemoryError:
+            all_psi_k = np.zeros((self.N, self.tau_max + 1, self.N, self.N), dtype="float16")
+            warnings.warn("Not enought memory. Reducing precision to float16."
 
         for k in range(self.N):
             all_psi_k[k] = self._get_psi_k(phi, k)


### PR DESCRIPTION
For a large N variables the matrix `np.zeros((N, tau_max +1, N, N)` scales quickly in RAM requirements. For those cases where there is not enough RAM, we try to lower the precision to `float16` which is of half precision but requires a quarter of the RAM. We raise a warning for the user.

Requires warnings to be imported. I forgot to write it... 