### PR TITLE
Fixed typo

### DIFF
--- a/tutorials/tigramite_tutorial_pcmciplus.ipynb
+++ b/tutorials/tigramite_tutorial_pcmciplus.ipynb
@@ -4268,7 +4268,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "False positives (grey) here appear due to indirect paths through contemporaneous parents. For example, $X^3_{t-1} \\to X^2_t$ appears due to the path $X^3_{t-1} \\to X^3_t \\to X^4_t$ because PCMCI only removes indirect links and common drivers that come through lagged parents, not those that come through contemporaneous parents. The same holds for the false contemporaneous link $X^2_{t} - X^4_t$ due to $X^2_{t} \\leftarrow X^3_t \\to X^4_t$. Further, all contemporaneous links remain undirected as indicated by the lines.\n",
+    "False positives (grey) here appear due to indirect paths through contemporaneous parents. For example, $X^3_{t-1} \\to X^2_t$ appears due to the path $X^3_{t-1} \\to X^3_t \\to X^2_t$ because PCMCI only removes indirect links and common drivers that come through lagged parents, not those that come through contemporaneous parents. The same holds for the false contemporaneous link $X^2_{t} - X^4_t$ due to $X^2_{t} \\leftarrow X^3_t \\to X^4_t$. Further, all contemporaneous links remain undirected as indicated by the lines.\n",
     "\n",
     "The comparison to the **PC algorithm (adapted to time series)** is fair since the underlying assumptions are the same:"
    ]


### PR DESCRIPTION
I'm quite sure it should be `X^2_t` here, since there is no path from `X^4_t` to `X^2_t`.