### PR TITLE
[BUG] fix var name in csv plotting

### DIFF
--- a/tigramite/plotting.py
+++ b/tigramite/plotting.py
@@ -4401,7 +4401,7 @@ def write_csv(
         for (i, j, tau) in zip(*np.where(graph!='')):
             # Only consider contemporaneous links once
             if tau > 0 or i <= j:
-                row = [str(var_names[i]), str(var_names[i]), f"{tau}", graph[i,j,tau]]
+                row = [str(var_names[i]), str(var_names[j]), f"{tau}", graph[i,j,tau]]
                 if val_matrix_exists:
                     row.append(f"{val_matrix[i,j,tau]:.{digits}}")
                 if link_attribute is not None:


### PR DESCRIPTION
Hi,

I found a bug in the `write_csv` function in plotting.py. When writing link (i,j) from the graph, var_names[i] is printed twice, var_names[j] should be used instead, as mentioned in the function documentation:
> Format is each link in a row as 'Variable i', 'Variable j', 'Time lag of i', 'Link type i --- j'

Please, have a look.
