### PR TITLE
Add dockerization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+.PHONY:	install_appuser \
+	install \
+	install_docker \
+	clean_docker \
+	docker_image \
+	docker_image_rebuild \
+	docker_devrun \
+	docker_localrun \
+	help
+
+GREEN  := $(shell tput -Txterm setaf 2)
+YELLOW := $(shell tput -Txterm setaf 3)
+WHITE  := $(shell tput -Txterm setaf 7)
+CYAN   := $(shell tput -Txterm setaf 6)
+RESET  := $(shell tput -Txterm sgr0)
+
+help: ## Show this help.
+	@echo 'Usage:'
+	@echo '  ${CYAN}make${RESET} ${GREEN}<target>${RESET}'
+	@echo ''
+	@echo 'Targets:'
+	@awk 'BEGIN {FS = ":.*?## "} { \
+		if (/^[a-zA-Z_-]+:.*?##.*$$/) {printf "  ${GREEN}%-21s${WHITE}%s${RESET}\n", $$1, $$2} \
+		else if (/^## .*$$/) {printf "  ${CYAN}%s${RESET}\n", substr($$1,4)} \
+		}' $(MAKEFILE_LIST)
+
+install_appuser: 
+	adduser --disabled-password appuser
+	gpasswd -a appuser sudo
+	printf "%s\\n" "appuser ALL=NOPASSWD: ALL" >> /etc/sudoers
+
+install_docker: install_appuser
+	mkdir --parents ./tmp/
+	chown --recursive appuser: /opt/tigramite/tmp
+
+install: ## Install tigramite.
+	sudo python3 ./setup.py install
+
+docker_image: ## Create docker image.
+	docker-compose --project-name tigramite_image --file docker/docker-compose-builder.yml build --progress plain $(FLAG)
+
+docker_image_rebuild: ## Re-create docker image, ignoring the cache.
+	docker-compose --project-name tigramite_image --file docker/docker-compose-builder.yml build --progress plain --no-cache $(FLAG)
+
+docker_devrun: ## Run dev container.
+	docker-compose --project-name tigramite_dev --file docker/docker-compose-development.yml run --rm app || true
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,8 @@
+FROM debian:bookworm-slim
+WORKDIR /opt/tigramite
+COPY ./docker/dependencies.txt ./docker/install_packages.sh ./
+RUN DEPFILE=./dependencies.txt ./install_packages.sh
+COPY . .
+RUN make install_docker
+RUN make install 
+USER appuser

--- a/docker/dependencies.txt
+++ b/docker/dependencies.txt
@@ -1,0 +1,19 @@
+# This is a list of Debian packages, we are depending on.
+# Be careful when editing the list, obey the given syntax.
+
+sudo
+python3
+python3-numpy
+python3-scipy
+python3-numba
+python3-matplotlib
+python3-seaborn
+python3-networkx
+python3-torch
+python3-joblib
+
+# Optional packages for development.
+
+vim
+make
+

--- a/docker/docker-compose-builder.yml
+++ b/docker/docker-compose-builder.yml
@@ -1,0 +1,12 @@
+---
+version: "3.7"
+
+services:
+  app:
+    image: ${DOCKER_REGISTRY_URL-tigramite}:${DOCKER_IMAGE_TAG-local}
+    build:
+      context: ./../
+      dockerfile: docker/Dockerfile
+      labels:
+        DOCKER_IMAGE_TAG: ${DOCKER_IMAGE_TAG-local}
+        DOCKER_REGISTRY_URL: ${DOCKER_REGISTRY_URL-tigramite}

--- a/docker/docker-compose-development.yml
+++ b/docker/docker-compose-development.yml
@@ -1,0 +1,13 @@
+---
+version: "3.9"
+
+services:
+  app:
+    image: tigramite:local
+    hostname: tigramite_dev
+    container_name: tigramite_dev
+    volumes:
+      - ./..:/opt/tigramite
+      - "/etc/timezone:/etc/timezone:ro"
+      - "/etc/localtime:/etc/localtime:ro"
+

--- a/docker/install_packages.sh
+++ b/docker/install_packages.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+DEPFILE="${DEPFILE:=./dependencies.txt}"
+
+set -e
+
+main()
+{
+    local proxy="${HTTP_PROXY:-$http_proxy}"
+
+    if [ -n "$proxy" ]
+    then
+        printf "Proxy %s was found, creating proxy.conf...\\n" "$proxy"
+        printf 'Acquire::http::Proxy "%s";\n' "$proxy" >> /etc/apt/apt.conf.d/proxy.conf
+    fi
+
+    printf "Update apt sources...\\n"
+
+    local err
+
+    if ! err="$(apt-get --assume-yes update 2>&1)"
+    then
+        printf "Could not update because: '%s'\\n" "$err"
+        exit 1
+    fi
+
+    mapfile -t < "$DEPFILE"
+
+    local packages=""
+
+    for line in "${MAPFILE[@]}"
+    do
+        [[ "$line" =~ ^[a-zA-Z0-9_] ]] && packages="$packages$line "
+    done
+
+    printf "Install packages %s...\\n" "$packages"
+
+    #shellcheck disable=SC2086
+    if ! err="$(apt-get --assume-yes install $packages 2>&1)"
+    then
+        printf "Could not install packages because: '%s'\\n" "$err"
+        exit 1
+    fi
+
+    rm --recursive --force /var/lib/apt/lists/*
+
+    exit 0
+}
+
+main


### PR DESCRIPTION
Tried to install tigramite on my machine (Debian Trixie) via
```
sudo python3 ./setup.py install
```
Got error message
```
RuntimeError: Cannot install on Python version 3.11.6; only versions >=3.7,<3.11 are supported.
```
Created docker image based on Debian Bookworm to bundle the correct dependencies. Added a helpful makefile. The whole thing should work like this:

1. Install docker and docker-compose
2. Cd into cloned tigramite repository
3. `make docker_image` - This will create a docker image with tigramite installed
4. `make docker_devrun` - This will start the container and spawn a shell. The tigramite repo will be mounted at /opt/ inside the container and can be altered from within the shell, as well as from the host system.
5. Now if you start python anywhere in the container, you should be able to import and use tigramite.

If you want to install additional dependencies or tools, adjust ./docker/dependencies.txt and execute `make docker_image_rebuild`