### PR TITLE
Update parameter of pc_stable for pcmci

### DIFF
--- a/tigramite/pcmci.py
+++ b/tigramite/pcmci.py
@@ -576,7 +576,7 @@ class PCMCI(PCMCIbase):
                       tau_min=1,
                       tau_max=1,
                       save_iterations=False,
-                      pc_alpha=0.2,
+                      pc_alpha=None,
                       max_conds_dim=None,
                       max_combinations=1):
         """Lagged PC algorithm for estimating lagged parents of all variables.


### PR DESCRIPTION
@jakobrunge 
In the documentation it is stated that default pc_alpha is a list (default: [0.05, 0.1, 0.2, ..., 0.5]).

On the other hand, the default value is 0.2 which is not converted to this list. By setting pc_alpha to None, the code converts it to the stated list.

Note: another option to solve this discrepancy is to modify the documentation, but I find it more interesting to have the optimization of pc_alpha as the default case.