### PR TITLE
Update .gitignore for macOS Temp Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 
 # Python byte code
 *.pyc
+
+# macOS Temp Files
+**/.DS_Store


### PR DESCRIPTION
Yes, I know it's a very small change — you can reject it and make the adjustment yourself if you prefer. Cleaning up the `.DS_Store` files might be a better approach.
